### PR TITLE
rubyref.net rather than rubyref.com

### DIFF
--- a/views/index.erb
+++ b/views/index.erb
@@ -11,7 +11,7 @@
 <body>
     <header>
         <div class="container">
-            <h1>rubyref.com</h1>
+            <h1>rubyref.net</h1>
         </div>
     </header>
     <div class="container">


### PR DESCRIPTION
Noticed the heading was .com rather than .net.  This corrects that.