### PR TITLE
Add JRuby

### DIFF
--- a/data/redirects.json
+++ b/data/redirects.json
@@ -4,6 +4,7 @@
   "capi": "https://docs.ruby-lang.org/en/trunk/extension_rdoc.html",
   "faq": "https://www.ruby-lang.org/en/documentation/faq/",
   "hard": "http://ruby.learncodethehardway.org/",
+  "jruby": "https://github.com/jruby/jruby/wiki",
   "koans": "http://rubykoans.com/",
   "monk": "http://rubymonk.com/",
   "mruby": "http://mruby.org/docs/api/",


### PR DESCRIPTION
Placed link to JRuby community wiki, there is a different documentation page (http://jruby.org/documentation). But I have found the community wiki to more useful and up to date.